### PR TITLE
Corrected and extended RandomSeed text

### DIFF
--- a/docs/potts.rst
+++ b/docs/potts.rst
@@ -237,10 +237,32 @@ boundary conditions you like.
 output text information about the status of the simulation. This tag is
 optional.
 
-``RandomSeed`` is used to initialize random number generator. If you do not
-do this all simulations will use same sequence of random numbers.
-Something you may want to avoid in the real simulations but is very
-useful while debugging your models.
+``RandomSeed`` is used to initialize the random number generator. If you 
+**do not include this tag** (and a value) then a **different** random seed will be chosen 
+for each run by the operating sytem and each simulation will use a 
+**different set of random nuymbers** and each simulaiton will produce a
+**different result**.
+In gerneal, this is the behavior you want. CompuCell3D simulations are meant 
+to be stoichsaistic and a simualtion represents a plausible trajectory of the 
+system through time. So generally you will **not** include a ``<RandomSeed>`` 
+element.
+
+However, in some cases, you want to force CompuCell3D to use the same random seed for 
+multiple runs so that it will proudce the same output everytime. This is often 
+useful for debugging or for when you are doing parameter estimation or 
+data fitting. In these cases you include the ``<RandomSeed>`` tag with an integer 
+of your choice. Every simualtion with the same seed will produce the same results.
+Note though that if you also use a random number generator in your Python code
+then you will need to specify a random seed there as well. The two seeds do 
+not have to be the same. For example, in your Python Steppables file you might
+include:
+
+.. code-block:: python
+
+    import random
+    random.seed(54321)
+
+This makes your python code use the same series of random numbers for every run.
 
 ``EnergyFunctionCalculator`` is another option of Potts object that allows
 users to output statistical data from the simulation for further


### PR DESCRIPTION
1. Fixed the incorrect explanation of what <RandomSeed> does 
2. Added section on also needing to set the seed in Python if the simulation uses random numbers in python.