### PR TITLE
Add link to tube initializer page

### DIFF
--- a/docs/section_steppable.rst
+++ b/docs/section_steppable.rst
@@ -35,6 +35,7 @@ familiar with `Developers' Manual <https://compucell3ddevelopersmanual.readthedo
 
     uniform_initializer
     blob_initializer
+    tube_initializer
     pif_initializer
     pif_dumper
     mitosis


### PR DESCRIPTION
Add link to tube initializer page  in the steppable section index (section_steppable.rst) so that user does not have to know the name of it to find it through search field. 